### PR TITLE
display file name if missing song name metadata

### DIFF
--- a/libmpdel.el
+++ b/libmpdel.el
@@ -247,8 +247,11 @@ message from the server.")
   (libmpdel--album-name album))
 
 (cl-defmethod libmpdel-entity-name ((song libmpdel-song))
-  "Return SONG's name."
-  (libmpdel--song-name song))
+  "Return SONG's name.
+
+If the SONG's name is nil, return the filename instead."
+  (or (libmpdel--song-name song)
+      (libmpdel--song-file song)))
 
 (cl-defmethod libmpdel-entity-name ((_entity (eql stored-playlists)))
   "Return a string describing the `stored-playlists' entity."

--- a/test/libmpdel-test.el
+++ b/test/libmpdel-test.el
@@ -94,6 +94,11 @@
     (should (equal "The song" (libmpdel-entity-name song)))
     (should (equal "The playlist" (libmpdel-entity-name stored-playlist)))))
 
+(ert-deftest libmpdel-test-entity-name-song-defaults-file ()
+  (let ((song (libmpdel--create-song-from-data
+               '((file . "foo/song.ogg")))))
+    (should (equal "foo/song.ogg" (libmpdel-entity-name song)))))
+
 (ert-deftest libmpdel-test-entity-parent ()
   (let* ((artist (libmpdel--artist-create :name "The Artist"))
          (album (libmpdel--album-create :name "The Album" :artist artist))


### PR DESCRIPTION
HTTP streams defined in playlist files do not contain metadata until
after the stream begins playing.  Therefore, it can be difficult to
distinguish between the streams when nothing is displayed for each entry
in the playlist.  I cannot foresee an instance where the file name is
missing, but this may be failure of my imagination.

Therefore, if the song title is missing, display the file name instead.

This behaviour is consistent with `ncmpcpp` sans special formatting
which `ncmpcpp` does to tracks starting with "http...".

See also: [mpdel/mpdel#2][0]

[0]: https://github.com/mpdel/mpdel/pull/2