### PR TITLE
Add support for multiple artists

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,7 @@ The library is implemented around a set of entities.
 | *Name*           | *Type*    | *Fields*             | *Description*                                           |
 |------------------+-----------+----------------------+---------------------------------------------------------|
 | song             | structure | name, album, file, … |                                                         |
-| album            | structure | name, date, artist   |                                                         |
+| album            | structure | name, date, artists  |                                                         |
 | artist           | structure | name                 |                                                         |
 | genre            | structure | name                 |                                                         |
 | directory        | structure | name, path           |                                                         |

--- a/libmpdel.el
+++ b/libmpdel.el
@@ -173,7 +173,7 @@ message from the server.")
                (:conc-name libmpdel--album-))
   (name nil :read-only t)
   (date nil :read-only t)
-  (artist nil :read-only t))
+  (artists nil :read-only t))
 
 (cl-defstruct (libmpdel-song
                (:constructor libmpdel--song-create)
@@ -214,16 +214,23 @@ message from the server.")
   "Return artist name of ENTITY."
   (libmpdel--artist-name (libmpdel-artist entity)))
 
+(defun libmpdel-artists-name (entity)
+  "Return semicolon separated string of artists names of ENTITY."
+  (string-join (mapcar #'libmpdel--artist-name
+                       (libmpdel-artists entity))
+               "; "))
+
 (cl-defgeneric libmpdel-artist (entity)
-  "Return artist of ENTITY.")
+  "Return artist of ENTITY."
+  (car (libmpdel-artists entity)))
 
-(cl-defmethod libmpdel-artist ((artist libmpdel-artist))
-  "Return ARTIST."
-  artist)
+(cl-defmethod libmpdel-artists ((artist libmpdel-artist))
+  "Return singleton list containing ARTIST."
+  (list artist))
 
-(cl-defmethod libmpdel-artist ((album libmpdel-album))
+(cl-defmethod libmpdel-artists ((album libmpdel-album))
   "Return the ALBUM's artist."
-  (libmpdel--album-artist album))
+  (libmpdel--album-artists album))
 
 (cl-defmethod libmpdel-artist ((song libmpdel-song))
   "Return the SONG's artist."
@@ -414,7 +421,7 @@ If the SONG's name is nil, return the filename instead."
   (libmpdel--album-create
    :name (cdr (assq 'Album song-data))
    :date (cdr (assq 'Date song-data))
-   :artist (libmpdel--artist-create :name (cdr (assq 'Artist song-data)))))
+   :artists (libmpdel--artists-create (libmpdel-entries song-data 'AlbumArtist))))
 
 (defun libmpdel--create-albums-from-data (data)
   "Return a list of albums from DATA, a server's response."
@@ -983,7 +990,11 @@ If HANDLER is nil, ignore response."
 (cl-defmethod libmpdel-entity-to-criteria ((album libmpdel-album))
   "Return search query matching all songs from ALBUM."
   (format "%s album %S"
-          (libmpdel-entity-to-criteria (libmpdel-artist album))
+          (string-join
+           (mapcar (lambda (artist)
+                     (format "albumartist %S" (libmpdel-entity-name artist)))
+                   (libmpdel-artists album))
+           " ")
           (libmpdel-entity-name album)))
 
 (cl-defmethod libmpdel-entity-to-criteria ((genre libmpdel-genre))

--- a/test/libmpdel-test.el
+++ b/test/libmpdel-test.el
@@ -63,7 +63,7 @@
 (ert-deftest libmpdel-test-artist-name ()
   (let* ((artist (libmpdel--artist-create :name "The Artist"))
          (album (libmpdel--album-create :name "The Album" :artists (list artist)))
-         (song (libmpdel--song-create :name "The song" :album album)))
+         (song (libmpdel--song-create :name "The song" :album album :artists (list artist))))
     (should (equal "The Artist" (libmpdel-artist-name artist)))
     (should (equal "The Artist" (libmpdel-artist-name album)))
     (should (equal "The Artist" (libmpdel-artist-name song)))))
@@ -132,6 +132,7 @@
     (should (equal "The Album" (libmpdel-entity-name (libmpdel-album song))))
     (should (equal (list "The Violinist" "The Pianist" "The Singer")
                    (mapcar #'libmpdel-entity-name (libmpdel-performers song))))
+    (should (equal "The Artist" (libmpdel-entity-name (libmpdel-artist song))))
     (should (equal "The Albumartist" (libmpdel-entity-name (libmpdel-artist (libmpdel-album song)))))))
 
 (ert-deftest libmpdel-test-current-playlist-p ()
@@ -295,7 +296,7 @@
                  (Artist . "Art")))))
    (libmpdel-test--with-connection
     (libmpdel-playlist-add song 'current-playlist)
-    (should (equal '("findadd albumartist \"Art\" albumartist \"Bart\" album \"A\" title \"S\"")
+    (should (equal '("findadd artist \"Art\" albumartist \"Art\" albumartist \"Bart\" album \"A\" title \"S\"")
                    (last commands))))))
 
 


### PR DESCRIPTION
MPD distinguishes between "AlbumArtist" and "Artist", and this reflects this distinction in libmpdel. Typical real world examples of when these differ are:

- artists that feature on an individual track of an album (these will not be in the AlbumArtist but will be in the Artist field), or
- compilation albums (in this case, the AlbumArtist is typically the compiler), or
- split albums (here, all tracks typically list both AlbumArtists but only one Artist)

This PR also adds support for multiple song/album artists per song/album.